### PR TITLE
cameraserver: Let multiple cameras opened by stock camera application

### DIFF
--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -1400,6 +1400,10 @@ void CameraService::finishConnectLocked(const sp<BasicClient>& client,
                     oomScoreOffset, systemNativeClient);
     auto evicted = mActiveClientManager.addAndEvict(clientDescriptor);
 
+    if (strcmp(String8(client->getPackageName()).string(), "com.android.camera") == 0) {
+        evicted.clear();
+    }
+
     logConnected(desc->getKey(), static_cast<int>(desc->getOwnerId()),
             String8(client->getPackageName()));
 
@@ -1509,6 +1513,9 @@ status_t CameraService::handleEvictionsLocked(const String8& cameraId, int clien
         // Find clients that would be evicted
         auto evicted = mActiveClientManager.wouldEvict(clientDescriptor);
 
+        if (strcmp(String8(packageName).string(), "com.android.camera") == 0) {
+            evicted.clear();
+        }
         // If the incoming client was 'evicted,' higher priority clients have the camera in the
         // background, so we cannot do evictions
         if (std::find(evicted.begin(), evicted.end(), clientDescriptor) != evicted.end()) {


### PR DESCRIPTION
`Let` conflicting camera devices list be empty and let the camera hal manage it. Old camera hals mark camera device as conflicting if the new camera device is opened. Fixes dual video camera mode for old devices